### PR TITLE
fuel plugin influxdb grafana for eayunstack 1.1

### DIFF
--- a/deployment_scripts/puppet/manifests/eayunstack_netconfig.pp
+++ b/deployment_scripts/puppet/manifests/eayunstack_netconfig.pp
@@ -1,0 +1,87 @@
+#    Copyright 2015 Mirantis, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+$influxdb_grafana = hiera('influxdb_grafana')
+
+if $influxdb_grafana['node_name'] == hiera('user_node_name') {
+  notice('MODULAR: eayunstack_netconfig.pp')
+
+#  $network_scheme = hiera('network_scheme')
+
+  class { 'l23network' :
+    use_ovs => hiera('use_neutron', false)
+  }
+#  prepare_network_config($network_scheme)
+#  $sdn = generate_network_config()
+#  notify {'SDN': message => $sdn }
+
+  #Set arp_accept to 1 by default #lp1456272
+  sysctl::value { 'net.ipv4.conf.all.arp_accept':   value => '1'  }
+  sysctl::value { 'net.ipv4.conf.default.arp_accept':   value => '1'  }
+
+  # setting kernel reserved ports
+  # defaults are 49000,49001,35357,41055,58882
+  class { 'openstack::reserved_ports': }
+
+  ### TCP connections keepalives and failover related parameters ###
+  # configure TCP keepalive for host OS.
+  # Send 3 probes each 8 seconds, if the connection was idle
+  # for a 30 seconds. Consider it dead, if there was no responces
+  # during the check time frame, i.e. 30+3*8=54 seconds overall.
+  # (note: overall check time frame should be lower then
+  # nova_report_interval).
+  class { 'openstack::keepalive' :
+    tcpka_time   => '30',
+    tcpka_probes => '8',
+    tcpka_intvl  => '3',
+    tcp_retries2 => '5',
+  }
+
+  # increase network backlog for performance on fast networks
+  sysctl::value { 'net.core.netdev_max_backlog':   value => '261144' }
+
+#  L2_port<||> -> Sysfs_config_value<||>
+#  L3_ifconfig<||> -> Sysfs_config_value<||>
+#  L3_route<||> -> Sysfs_config_value<||>
+
+  class { 'sysfs' :}
+
+  sysfs_config_value { 'rps_cpus' :
+    ensure  => 'present',
+    name    => '/etc/sysfs.d/rps_cpus.conf',
+    value   => cpu_affinity_hex($::processorcount),
+    sysfs   => '/sys/class/net/*/queues/rx-*/rps_cpus',
+    exclude => '/sys/class/net/lo/*',
+  }
+
+  sysfs_config_value { 'xps_cpus' :
+    ensure  => 'present',
+    name    => '/etc/sysfs.d/xps_cpus.conf',
+    value   => cpu_affinity_hex($::processorcount),
+    sysfs   => '/sys/class/net/*/queues/tx-*/xps_cpus',
+    exclude => '/sys/class/net/lo/*',
+  }
+
+  if !defined(Package['irqbalance']) {
+    package { 'irqbalance':
+      ensure => installed,
+    }
+  }
+
+  if !defined(Service['irqbalance']) {
+    service { 'irqbalance':
+      ensure  => running,
+      require => Package['irqbalance'],
+    }
+  }
+}

--- a/deployment_scripts/puppet/modules/lma_monitoring_analytics/templates/configure_influxdb.sh.erb
+++ b/deployment_scripts/puppet/modules/lma_monitoring_analytics/templates/configure_influxdb.sh.erb
@@ -2,6 +2,8 @@
 
 set -eux
 
+sleep 10
+
 INFLUXDB_URL="http://127.0.0.1:8086"
 
 # Setup the new root password

--- a/deployment_scripts/puppet/modules/lma_monitoring_analytics/templates/grafana_dashboards/Main.json
+++ b/deployment_scripts/puppet/modules/lma_monitoring_analytics/templates/grafana_dashboards/Main.json
@@ -540,8 +540,8 @@
             {
               "function": "last",
               "column": "value",
-              "series": "merge(/\\.rabbitmq.status$/)",
-              "query": "select last(value) from merge(/\\.rabbitmq.status$/) where $timeFilter group by time($interval) order asc",
+              "series": "merge(/node-[0-9][0-9]*[0-9]*[0-9]*[0-9]*.rabbitmq.status$/)",
+              "query": "select last(value) from merge(/node-[0-9][0-9]*[0-9]*[0-9]*[0-9]*.rabbitmq.status$/) where $timeFilter group by time($interval) order asc",
               "rawQuery": false,
               "interval": "",
               "fill": ""

--- a/deployment_scripts/puppet/modules/lma_monitoring_analytics/templates/grafana_dashboards/Neutron.json
+++ b/deployment_scripts/puppet/modules/lma_monitoring_analytics/templates/grafana_dashboards/Neutron.json
@@ -590,7 +590,7 @@
         {
           "title": "dhcp",
           "error": false,
-          "span": 2,
+          "span": 1,
           "editable": true,
           "type": "singlestat",
           "id": 15,
@@ -641,7 +641,7 @@
         {
           "title": "L3",
           "error": false,
-          "span": 2,
+          "span": 1,
           "editable": true,
           "type": "singlestat",
           "id": 16,
@@ -692,7 +692,7 @@
         {
           "title": "metadata",
           "error": false,
-          "span": 2,
+          "span": 1,
           "editable": true,
           "type": "singlestat",
           "id": 17,
@@ -743,7 +743,7 @@
         {
           "title": "openvswitch",
           "error": false,
-          "span": 3,
+          "span": 1,
           "editable": true,
           "type": "singlestat",
           "id": 18,
@@ -792,14 +792,116 @@
           }
         },
         {
+          "title": "lbaas",
+          "error": false,
+          "span": 1,
+          "editable": true,
+          "type": "singlestat",
+          "id": 19,
+          "links": [],
+          "maxDataPoints": 100,
+          "interval": "> 60s",
+          "targets": [
+            {
+              "function": "last",
+              "column": "value",
+              "series": "merge(/openstack.neutron.agents.lbaas.disabled/)",
+              "query": "select last(value) from merge(/openstack.neutron.agents.lbaas.disabled/) where $timeFilter group by time($interval) order asc",
+              "fill": ""
+            }
+          ],
+          "cacheTimeout": null,
+          "format": "none",
+          "prefix": "",
+          "postfix": "",
+          "nullText": null,
+          "valueMaps": [
+            {
+              "value": "null",
+              "op": "=",
+              "text": "N/A"
+            }
+          ],
+          "nullPointMode": "connected",
+          "valueName": "current",
+          "prefixFontSize": "50%",
+          "valueFontSize": "80%",
+          "postfixFontSize": "50%",
+          "thresholds": "0,1,1",
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "sparkline": {
+            "show": false,
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "fillColor": "rgba(31, 118, 189, 0.18)"
+          }
+        },
+        {
+          "title": "qos",
+          "error": false,
+          "span": 1,
+          "editable": true,
+          "type": "singlestat",
+          "id": 20,
+          "links": [],
+          "maxDataPoints": 100,
+          "interval": "> 60s",
+          "targets": [
+            {
+              "function": "last",
+              "column": "value",
+              "series": "merge(/openstack.neutron.agents.qos.disabled/)",
+              "query": "select last(value) from merge(/openstack.neutron.agents.qos.disabled/) where $timeFilter group by time($interval) order asc",
+              "fill": ""
+            }
+          ],
+          "cacheTimeout": null,
+          "format": "none",
+          "prefix": "",
+          "postfix": "",
+          "nullText": null,
+          "valueMaps": [
+            {
+              "value": "null",
+              "op": "=",
+              "text": "N/A"
+            }
+          ],
+          "nullPointMode": "connected",
+          "valueName": "current",
+          "prefixFontSize": "50%",
+          "valueFontSize": "80%",
+          "postfixFontSize": "50%",
+          "thresholds": "0,1,1",
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "sparkline": {
+            "show": false,
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "fillColor": "rgba(31, 118, 189, 0.18)"
+          }
+        },
+        {
           "title": "",
           "error": false,
-          "span": 2,
+          "span": 4,
           "editable": true,
           "type": "text",
-          "id": 19,
-          "mode": "html",
-          "content": "<br />\n<h3 align=\"center\"> Up </h3>",
+          "id": 21,
+          "mode": "text",
+          "content": "",
           "style": {},
           "links": []
         },
@@ -808,8 +910,20 @@
           "error": false,
           "span": 2,
           "editable": true,
+          "type": "text",
+          "id": 22,
+          "mode": "html",
+          "content": "<br />\n<h3 align=\"center\"> Up </h3>",
+          "style": {},
+          "links": []
+        },
+        {
+          "title": "",
+          "error": false,
+          "span": 1,
+          "editable": true,
           "type": "singlestat",
-          "id": 20,
+          "id": 23,
           "links": [],
           "maxDataPoints": 100,
           "interval": "> 60s",
@@ -857,10 +971,10 @@
         {
           "title": "",
           "error": false,
-          "span": 2,
+          "span": 1,
           "editable": true,
           "type": "singlestat",
-          "id": 21,
+          "id": 24,
           "links": [],
           "maxDataPoints": 100,
           "interval": "> 60s",
@@ -908,10 +1022,10 @@
         {
           "title": "",
           "error": false,
-          "span": 2,
+          "span": 1,
           "editable": true,
           "type": "singlestat",
-          "id": 22,
+          "id": 25,
           "links": [],
           "maxDataPoints": 100,
           "interval": "> 60s",
@@ -959,10 +1073,10 @@
         {
           "title": "",
           "error": false,
-          "span": 3,
+          "span": 1,
           "editable": true,
           "type": "singlestat",
-          "id": 23,
+          "id": 26,
           "links": [],
           "maxDataPoints": 100,
           "interval": "> 60s",
@@ -1010,12 +1124,114 @@
         {
           "title": "",
           "error": false,
-          "span": 2,
+          "span": 1,
+          "editable": true,
+          "type": "singlestat",
+          "id": 27,
+          "links": [],
+          "maxDataPoints": 100,
+          "interval": "> 60s",
+          "targets": [
+            {
+              "function": "last",
+              "column": "value",
+              "series": "merge(/openstack.neutron.agents.lbaas.up/)",
+              "query": "select last(value) from merge(/openstack.neutron.agents.lbaas.up/) where $timeFilter group by time($interval) order asc",
+              "fill": ""
+            }
+          ],
+          "cacheTimeout": null,
+          "format": "none",
+          "prefix": "",
+          "postfix": "",
+          "nullText": null,
+          "valueMaps": [
+            {
+              "value": "null",
+              "op": "=",
+              "text": "N/A"
+            }
+          ],
+          "nullPointMode": "connected",
+          "valueName": "current",
+          "prefixFontSize": "50%",
+          "valueFontSize": "80%",
+          "postfixFontSize": "50%",
+          "thresholds": "0,1,1",
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "sparkline": {
+            "show": false,
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "fillColor": "rgba(31, 118, 189, 0.18)"
+          }
+        },
+        {
+          "title": "",
+          "error": false,
+          "span": 1,
+          "editable": true,
+          "type": "singlestat",
+          "id": 28,
+          "links": [],
+          "maxDataPoints": 100,
+          "interval": "> 60s",
+          "targets": [
+            {
+              "function": "last",
+              "column": "value",
+              "series": "merge(/openstack.neutron.agents.qos.up/)",
+              "query": "select last(value) from merge(/openstack.neutron.agents.qos.up/) where $timeFilter group by time($interval) order asc",
+              "fill": ""
+            }
+          ],
+          "cacheTimeout": null,
+          "format": "none",
+          "prefix": "",
+          "postfix": "",
+          "nullText": null,
+          "valueMaps": [
+            {
+              "value": "null",
+              "op": "=",
+              "text": "N/A"
+            }
+          ],
+          "nullPointMode": "connected",
+          "valueName": "current",
+          "prefixFontSize": "50%",
+          "valueFontSize": "80%",
+          "postfixFontSize": "50%",
+          "thresholds": "0,1,1",
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "sparkline": {
+            "show": false,
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "fillColor": "rgba(31, 118, 189, 0.18)"
+          }
+        },
+        {
+          "title": "",
+          "error": false,
+          "span": 4,
           "editable": true,
           "type": "text",
-          "id": 24,
-          "mode": "html",
-          "content": "<br />\n<h3 align=\"center\"> Down </h3>",
+          "id": 29,
+          "mode": "text",
+          "content": "",
           "style": {},
           "links": []
         },
@@ -1024,8 +1240,20 @@
           "error": false,
           "span": 2,
           "editable": true,
+          "type": "text",
+          "id": 30,
+          "mode": "html",
+          "content": "<br />\n<h3 align=\"center\"> Down </h3>",
+          "style": {},
+          "links": []
+        },
+        {
+          "title": "",
+          "error": false,
+          "span": 1,
+          "editable": true,
           "type": "singlestat",
-          "id": 25,
+          "id": 31,
           "links": [],
           "maxDataPoints": 100,
           "interval": "> 60s",
@@ -1073,10 +1301,10 @@
         {
           "title": "",
           "error": false,
-          "span": 2,
+          "span": 1,
           "editable": true,
           "type": "singlestat",
-          "id": 26,
+          "id": 32,
           "links": [],
           "maxDataPoints": 100,
           "interval": "> 60s",
@@ -1124,10 +1352,10 @@
         {
           "title": "",
           "error": false,
-          "span": 2,
+          "span": 1,
           "editable": true,
           "type": "singlestat",
-          "id": 27,
+          "id": 33,
           "links": [],
           "maxDataPoints": 100,
           "interval": "> 60s",
@@ -1175,10 +1403,10 @@
         {
           "title": "",
           "error": false,
-          "span": 3,
+          "span": 1,
           "editable": true,
           "type": "singlestat",
-          "id": 28,
+          "id": 34,
           "links": [],
           "maxDataPoints": 100,
           "interval": "> 60s",
@@ -1222,6 +1450,120 @@
             "lineColor": "rgb(31, 120, 193)",
             "fillColor": "rgba(31, 118, 189, 0.18)"
           }
+        },
+        {
+          "title": "",
+          "error": false,
+          "span": 1,
+          "editable": true,
+          "type": "singlestat",
+          "id": 35,
+          "links": [],
+          "maxDataPoints": 100,
+          "interval": "> 60s",
+          "targets": [
+            {
+              "function": "last",
+              "column": "value",
+              "series": "merge(/openstack.neutron.agents.lbaas.down/)",
+              "query": "select last(value) from merge(/openstack.neutron.agents.lbaas.down/) where $timeFilter group by time($interval) order asc",
+              "fill": ""
+            }
+          ],
+          "cacheTimeout": null,
+          "format": "none",
+          "prefix": "",
+          "postfix": "",
+          "nullText": null,
+          "valueMaps": [
+            {
+              "value": "null",
+              "op": "=",
+              "text": "N/A"
+            }
+          ],
+          "nullPointMode": "connected",
+          "valueName": "current",
+          "prefixFontSize": "50%",
+          "valueFontSize": "80%",
+          "postfixFontSize": "50%",
+          "thresholds": "1,0,0",
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(255, 255, 255, 0.89)",
+            "rgba(255, 255, 255, 0.97)"
+          ],
+          "sparkline": {
+            "show": false,
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "fillColor": "rgba(31, 118, 189, 0.18)"
+          }
+        },
+        {
+          "title": "",
+          "error": false,
+          "span": 1,
+          "editable": true,
+          "type": "singlestat",
+          "id": 36,
+          "links": [],
+          "maxDataPoints": 100,
+          "interval": "> 60s",
+          "targets": [
+            {
+              "function": "last",
+              "column": "value",
+              "series": "merge(/openstack.neutron.agents.qos.down/)",
+              "query": "select last(value) from merge(/openstack.neutron.agents.qos.down/) where $timeFilter group by time($interval) order asc",
+              "fill": ""
+            }
+          ],
+          "cacheTimeout": null,
+          "format": "none",
+          "prefix": "",
+          "postfix": "",
+          "nullText": null,
+          "valueMaps": [
+            {
+              "value": "null",
+              "op": "=",
+              "text": "N/A"
+            }
+          ],
+          "nullPointMode": "connected",
+          "valueName": "current",
+          "prefixFontSize": "50%",
+          "valueFontSize": "80%",
+          "postfixFontSize": "50%",
+          "thresholds": "1,0,0",
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(255, 255, 255, 0.89)",
+            "rgba(255, 255, 255, 0.97)"
+          ],
+          "sparkline": {
+            "show": false,
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "fillColor": "rgba(31, 118, 189, 0.18)"
+          }
+        },
+        {
+          "title": "",
+          "error": false,
+          "span": 4,
+          "editable": true,
+          "type": "text",
+          "id": 37,
+          "mode": "text",
+          "content": "",
+          "style": {},
+          "links": []
         }
       ],
       "showTitle": true

--- a/environment_config.yaml
+++ b/environment_config.yaml
@@ -1,4 +1,8 @@
 attributes:
+  metadata:
+    restrictions:
+        - condition: "true"
+          action: "hide"
 
   node_name:
     value: 'influxdb'

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,7 +7,7 @@ version: '0.7.2'
 # Description
 description: Deploy InfluxDB server and the Grafana web interface.
 # Required fuel version
-fuel_version: ['6.1', '7.0']
+fuel_version: ['6.0']
 # Specify license of your plugin
 licenses: ['Apache License Version 2.0']
 # Specify author or company name
@@ -31,10 +31,10 @@ releases:
     deployment_scripts_path: deployment_scripts/
     repository_path: repositories/ubuntu
   - os: centos
-    version: 2014.2-6.1
+    version: 2014.2-6.0.1
     mode: ['ha', 'multinode']
     deployment_scripts_path: deployment_scripts/
     repository_path: repositories/centos
 
 # Version of plugin package
-package_version: '2.0.0'
+package_version: '1.0.0'

--- a/pre_build_hook
+++ b/pre_build_hook
@@ -7,19 +7,21 @@ RPM_REPO="${ROOT}"/repositories/centos/
 DEB_REPO="${ROOT}"/repositories/ubuntu/
 
 # Puppet manifests for influx
-INFLUXDB_TARBALL_URL="https://forgeapi.puppetlabs.com/v3/files/jdowning-influxdb-0.3.0.tar.gz"
-STAGING_TARBALL_URL="https://forgeapi.puppetlabs.com/v3/files/nanliu-staging-1.0.3.tar.gz"
+INFLUXDB_TARBALL_URL="http://192.168.5.19/fuel-plugins-tarball/jdowning-influxdb-0.3.0.tar.gz"
+STAGING_TARBALL_URL="http://192.168.5.19/fuel-plugins-tarball/nanliu-staging-1.0.3.tar.gz"
 
 # Puppet manifests required for grafana
-NGINX_TARBALL_URL="https://forgeapi.puppetlabs.com/v3/files/jfryman-nginx-0.2.2.tar.gz"
+NGINX_TARBALL_URL="http://192.168.5.19/fuel-plugins-tarball/jfryman-nginx-0.2.2.tar.gz"
 
 # Puppet manifests from fuel-lib
 FUEL_LIB_VERSION="6.0"
-FUEL_LIB_TARBALL_URL="https://github.com/stackforge/fuel-library/archive/${FUEL_LIB_VERSION}.tar.gz"
+FUEL_LIB_TARBALL_URL="http://192.168.5.19/fuel-library/${FUEL_LIB_VERSION}.tar.gz"
+FUEL_LIB_VERSION_6_1="6.1"
+FUEL_LIB_TARBALL_URL_6_1="http://192.168.5.19/fuel-library/${FUEL_LIB_VERSION_6_1}.tar.gz"
 
 # Get the disk_management from fuel-plugin-elasticsearch-kibana
 ES_KIBANA_VERSION="0.7.2"
-MODULE_DISK_MANAGEMENT="https://github.com/stackforge/fuel-plugin-elasticsearch-kibana/archive/${ES_KIBANA_VERSION}.tar.gz"
+MODULE_DISK_MANAGEMENT="http://192.168.5.19/fuel-plugins-tarball/fuel-plugin-elasticsearch-kibana-0.7.2.tar.gz"
 
 # Downloads needed RPM or DEB packages
 function download {
@@ -36,12 +38,11 @@ function download {
     done
 }
 
-download deb http://get.influxdb.org/influxdb_0.8.8_amd64.deb
-download rpm http://get.influxdb.org/influxdb-0.8.8-1.x86_64.rpm
+download rpm http://192.168.5.19/fuel-plugins/centos/Packages/influxdb-0.8.8-1.x86_64.rpm
 
 # Install puppet manifests
 # Clean-up first
-rm -rf "${MODULES:?}"/{influxdb,nginx,staging,stdlib,concat,inifile,disk_management,lvm}
+rm -rf "${MODULES:?}"/{influxdb,nginx,staging,stdlib,concat,inifile,disk_management,lvm,firewall,l23network,openstack,sysctl,tweaks,sysfs}
 mkdir -p "${MODULES}"/{influxdb,nginx,staging}
 
 # Include influxdb manifests, its dependendy and nginx.
@@ -52,7 +53,12 @@ wget -qO- "${NGINX_TARBALL_URL}" | tar -C "${MODULES}/nginx" --strip-components=
 # Include dependent manifests from fuel-library
 wget -qO- "${FUEL_LIB_TARBALL_URL}" | \
     tar -C "${MODULES}" --strip-components=3 -zxvf - \
-    fuel-library-${FUEL_LIB_VERSION}/deployment/puppet/{stdlib,concat,inifile,lvm}
+    fuel-library-${FUEL_LIB_VERSION}/deployment/puppet/{stdlib,concat,inifile,lvm,firewall,l23network,openstack,sysctl,tweaks}
+
+# Include dependent manifests from fuel-library-6.1
+wget -qO- "${FUEL_LIB_TARBALL_URL_6_1}" | \
+    tar -C "${MODULES}" --strip-components=3 -zxvf - \
+    fuel-library-${FUEL_LIB_VERSION_6_1}/deployment/puppet/sysfs
 
 # Include disk_management
 wget -qO- "${MODULE_DISK_MANAGEMENT}" | \
@@ -60,7 +66,7 @@ wget -qO- "${MODULE_DISK_MANAGEMENT}" | \
     fuel-plugin-elasticsearch-kibana-${ES_KIBANA_VERSION}/deployment_scripts/puppet/modules/disk_management
 
 # We need to embed grafana sources into the lma_monitoring_analytics module.
-GRAFANA_TARBALL_URL="http://grafanarel.s3.amazonaws.com/grafana-1.9.1.tar.gz"
+GRAFANA_TARBALL_URL="http://192.168.5.19/fuel-plugins-tarball/grafana-1.9.1.tar.gz"
 GRAFANA_FOLDER="${MODULES}/lma_monitoring_analytics/files/grafana/sources"
 mkdir -p "${GRAFANA_FOLDER}"
 wget -qO- "${GRAFANA_TARBALL_URL}" | tar -C "${GRAFANA_FOLDER}" --strip-components=1 -xz

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -1,6 +1,6 @@
 # This task is executed before any real deployment task
 - role: ['base-os']
-  stage: post_deployment/8000
+  stage: post_deployment
   type: puppet
   parameters:
     puppet_manifest: puppet/manifests/check_environment_configuration.pp
@@ -9,7 +9,7 @@
 
 # The following tasks are executed in the order they are declared
 - role: ['base-os']
-  stage: post_deployment/8100
+  stage: post_deployment
   type: puppet
   parameters:
     puppet_manifest: puppet/manifests/netconfig.pp
@@ -17,7 +17,7 @@
     timeout: 720
 
 - role: ['base-os']
-  stage: post_deployment/8100
+  stage: post_deployment
   type: puppet
   parameters:
     puppet_manifest: puppet/manifests/firewall.pp
@@ -25,7 +25,7 @@
     timeout: 300
 
 - role: ['base-os']
-  stage: post_deployment/8100
+  stage: post_deployment
   type: puppet
   parameters:
     puppet_manifest: puppet/manifests/setup_disks.pp
@@ -33,13 +33,7 @@
     timeout: 600
 
 - role: ['base-os']
-  stage: post_deployment/8100
-  type: reboot
-  parameters:
-    timeout: 600
-
-- role: ['base-os']
-  stage: post_deployment/8100
+  stage: post_deployment
   type: puppet
   parameters:
     puppet_manifest: puppet/manifests/setup_influxdir.pp
@@ -47,7 +41,7 @@
     timeout: 600
 
 - role: ['base-os']
-  stage: post_deployment/8100
+  stage: post_deployment
   type: puppet
   parameters:
     puppet_manifest: puppet/manifests/influxdb.pp
@@ -55,7 +49,7 @@
     timeout: 600
 
 - role: ['base-os']
-  stage: post_deployment/8100
+  stage: post_deployment
   type: puppet
   parameters:
     puppet_manifest: puppet/manifests/grafana.pp


### PR DESCRIPTION
- 修改了metadata.yaml文件：
  - 修改了相关版本号，解决了上游代码(基于fuel 6.1)与eayunstack环境(基于fuel 6.0.1)代码中相关版本号不匹配的问题；
- 修改了 pre_build_hook文件：
  - 修改了相关tar包及rpm包的下载地址，有利于版本控制及提高打包速度；
  - 增加了从fuel-library-6.0中下载firewall,l23network,openstack,sysctl,tweaks模块；
  - 增加了从fuel-library-6.1中下载sysfs模块；
- 修改了task.yaml文件：
  - 解决了上游代码(基于fuel 6.1)与eayunstack环境(基于 fuel 6.0.1)相关代码冲突的问题；
- 修改了configure_influxdb.sh.erb文件：
  - 解决了influxdb数据库配置时报"127.0.0.1:8086"端口连接失败的问题；
- 增加了eayunstack_netconfig.pp文件：
  - 针对eayunstack环境对netconfig.pp文件进行了相关修改；
- 修改了Main.json文件：
  - 解决了grafana Main界面rabbitmq状态偶尔显示为“FAIL“的问题；
- 修改了environment_config.yaml文件：
  - 隐藏Fuel WEB UI关于该插件的配置
- 修改了Neutron.json文件：
  - grafana Neutron界面增加了对lbaas和qos agent的状态的监控
